### PR TITLE
Correcting REx implementation

### DIFF
--- a/tf_policy_loss_calculations.ipynb
+++ b/tf_policy_loss_calculations.ipynb
@@ -1,0 +1,773 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rex_beta = 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 2, 3), dtype=float32, numpy=\n",
+       "array([[[ 0.,  1.,  2.],\n",
+       "        [ 3.,  4.,  5.]],\n",
+       "\n",
+       "       [[ 6.,  7.,  8.],\n",
+       "        [ 9., 10., 11.]],\n",
+       "\n",
+       "       [[12., 13., 14.],\n",
+       "        [15., 16., 17.]],\n",
+       "\n",
+       "       [[18., 19., 20.],\n",
+       "        [21., 22., 23.]]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "losses_arr = tf.reshape(tf.range(24, dtype=float), (4,2,3))\n",
+    "losses = tf.constant(losses_arr)\n",
+    "losses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# policies = tf.constant([\n",
+    "#     [\n",
+    "#         [1.],\n",
+    "#         [1.]\n",
+    "#     ],\n",
+    "#     [\n",
+    "#         [1.],\n",
+    "#         [0.]\n",
+    "#     ],\n",
+    "#     [\n",
+    "#         [0.],\n",
+    "#         [2.]\n",
+    "#     ],\n",
+    "#     [\n",
+    "#         [0.],\n",
+    "#         [1.]\n",
+    "#     ]\n",
+    "\n",
+    "# ])\n",
+    "# policies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 2, 1), dtype=float32, numpy=\n",
+       "array([[[1.],\n",
+       "        [1.]],\n",
+       "\n",
+       "       [[1.],\n",
+       "        [0.]],\n",
+       "\n",
+       "       [[0.],\n",
+       "        [2.]],\n",
+       "\n",
+       "       [[0.],\n",
+       "        [1.]]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "policies = tf.constant([\n",
+    "    [\n",
+    "        [1.],\n",
+    "        [1.]\n",
+    "    ],\n",
+    "    [\n",
+    "        [1.],\n",
+    "        [0.]\n",
+    "    ],\n",
+    "    [\n",
+    "        [0.],\n",
+    "        [2.]\n",
+    "    ],\n",
+    "    [\n",
+    "        [0.],\n",
+    "        [1.]\n",
+    "    ]\n",
+    "\n",
+    "])\n",
+    "policies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 2, 1), dtype=float32, numpy=\n",
+       "array([[[ 1.],\n",
+       "        [ 4.]],\n",
+       "\n",
+       "       [[ 7.],\n",
+       "        [10.]],\n",
+       "\n",
+       "       [[13.],\n",
+       "        [16.]],\n",
+       "\n",
+       "       [[19.],\n",
+       "        [22.]]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obs_losses = tf.reduce_mean(losses, axis=-1, keepdims=True)\n",
+    "obs_losses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Solution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 2, 1), dtype=int32, numpy=\n",
+       "array([[[1],\n",
+       "        [1]],\n",
+       "\n",
+       "       [[1],\n",
+       "        [0]],\n",
+       "\n",
+       "       [[0],\n",
+       "        [2]],\n",
+       "\n",
+       "       [[0],\n",
+       "        [1]]], dtype=int32)>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "policies = tf.cast(policies, tf.int32)\n",
+    "policies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(3,), dtype=int32, numpy=array([1, 0, 2], dtype=int32)>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unique_pols = tf.unique(tf.reshape(policies, [-1])).y\n",
+    "unique_pols"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(), dtype=int32, numpy=3>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.reduce_max(unique_pols+1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 2, 3), dtype=float32, numpy=\n",
+       "array([[[0., 1., 0.],\n",
+       "        [0., 1., 0.]],\n",
+       "\n",
+       "       [[0., 1., 0.],\n",
+       "        [1., 0., 0.]],\n",
+       "\n",
+       "       [[1., 0., 0.],\n",
+       "        [0., 0., 1.]],\n",
+       "\n",
+       "       [[1., 0., 0.],\n",
+       "        [0., 1., 0.]]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pol_one_hot = tf.squeeze(tf.one_hot(policies, tf.reduce_max(unique_pols+1), axis=-1), axis=-2)\n",
+    "pol_one_hot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 3), dtype=float32, numpy=\n",
+       "array([[ 0.,  5.,  0.],\n",
+       "       [10.,  7.,  0.],\n",
+       "       [13.,  0., 16.],\n",
+       "       [19., 22.,  0.]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pol_mean_sum = tf.squeeze(tf.matmul(tf.transpose(pol_one_hot, [0,2,1]), obs_losses), axis=-1)\n",
+    "pol_mean_sum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 3), dtype=float32, numpy=\n",
+       "array([[0., 2., 0.],\n",
+       "       [1., 1., 0.],\n",
+       "       [1., 0., 1.],\n",
+       "       [1., 1., 0.]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pol_count = tf.reduce_sum(pol_one_hot, axis=-2)\n",
+    "pol_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4, 3), dtype=float32, numpy=\n",
+       "array([[ 0. ,  2.5,  0. ],\n",
+       "       [10. ,  7. ,  0. ],\n",
+       "       [13. ,  0. , 16. ],\n",
+       "       [19. , 22. ,  0. ]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "policy_losses = tf.math.divide_no_nan(pol_mean_sum, pol_count)\n",
+    "policy_losses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4,), dtype=float32, numpy=array([ 2.5, 17. , 29. , 41. ], dtype=float32)>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total_loss = tf.reduce_sum(policy_losses,axis=-1)\n",
+    "total_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2.5, 8.5, 14.5, 20.5)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.mean(np.arange(0.,6.)), np.mean(np.arange(6.,12.)), np.mean(np.arange(12.,18.)), np.mean(np.arange(18.,24.))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4,), dtype=float32, numpy=array([ 2.5, 17. , 29. , 41. ], dtype=float32)>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.math.reduce_sum(tf.ragged.boolean_mask(policy_losses, pol_count>0.),axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4,), dtype=float32, numpy=array([0.  , 2.25, 2.25, 2.25], dtype=float32)>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loss_var = tf.math.reduce_variance(tf.ragged.boolean_mask(policy_losses, pol_count>0.), axis=-1)\n",
+    "loss_var"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(4,), dtype=float32, numpy=array([ 2.5 , 19.25, 31.25, 43.25], dtype=float32)>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total_loss_var = total_loss + loss_var\n",
+    "total_loss_var"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Alternate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.concat((losses, policies), axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_member(x):\n",
+    "    data, pol = x[:,:-1], x[:,-1:]\n",
+    "    def process_pol(y):\n",
+    "        mask = tf.tile(tf.equal(pol,y),(1,data.shape[-1]))\n",
+    "        return tf.reduce_mean(tf.boolean_mask(data, mask))\n",
+    "    return tf.map_fn(process_pol, unique_pols)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = tf.map_fn(process_member, tf.concat((losses, policies), axis=-1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.reduce_sum(result, axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tf.math.unsorted_segment_mean(losses, tf.cast(policies, tf.int64), 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Original"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_pol = tf.where(tf.equal(tf.tile(policies,(1,1,losses.shape[-1])),unique_pols[0]), losses, tf.zeros_like(losses))\n",
+    "mean_pol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.reduce_mean(mean_pol, axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.reduce_mean(tf.reduce_mean(mean_pol, axis=-1), axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = tf.tile(tf.equal(policies, unique_pols[0]), (1,1,3))\n",
+    "mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.boolean_mask(losses, mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = tf.tile(tf.equal(policies[0,:,:], unique_pols[0]), (1,losses[0,:,:].shape[-1]))\n",
+    "mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.tile(tf.equal(policies[0,:,:], unique_pols[0]), (1,losses[0,:,:].shape[-1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = tf.concat((losses, policies), axis=-1)[0,:,:]\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data, pol = x[:,:-1], x[:,-1:]\n",
+    "data, pol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = tf.tile(tf.equal(pol, unique_pols[0]), (1,data.shape[-1]))\n",
+    "tf.reduce_mean(tf.boolean_mask(data, mask))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.concat((losses, policies), axis=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = tf.equal(policies, unique_pols[0])\n",
+    "tf.boolean_mask(losses, mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.ragged.boolean_mask(losses, tf.tile(tf.equal(policies, unique_pols[1]),(1,1,3)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simple_ret(x):\n",
+    "    return x[:,-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.map_fn(simple_ret, tf.concat((mean, policies), axis=-1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logits = tf.constant([[[10.0, 10.0, 20.0, 20.0],\n",
+    "                      [11.0, 10.0, 10.0, 30.0],\n",
+    "                      [12.0, 10.0, 10.0, 20.0],\n",
+    "                      [13.0, 10.0, 10.0, 20.0]],\n",
+    "                     [[14.0, 11.0, 21.0, 31.0],\n",
+    "                      [15.0, 11.0, 11.0, 21.0],\n",
+    "                      [16.0, 11.0, 11.0, 21.0],\n",
+    "                      [17.0, 11.0, 11.0, 21.0]]])\n",
+    "\n",
+    "indices = tf.constant([[[0, 0], [0, 1]], [[1, 1], [1, 3]]])\n",
+    "\n",
+    "result = tf.gather_nd(logits, indices)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logits.shape, indices.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.slice(mean, tf.cast(policies, tf.int64))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "0762be2d7dad499f78b4ccc05029bbe082222b827c654f817432570f6c80b9f2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.13",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Initial REx implementation used a mask to set the losses for records not belonging to the policy currently being considered to 0. However, when the average was calculated, the zeros would be included in the denominator, and so the averages were being suppressed.

This PR corrects this issue, and ensure the variances are correctly calculated.

A jupyter notebook is included which illustrates the operation of the new method, and can be used to verify its correctness.