### PR TITLE
Train Dynamics Only; No Additional Training; Learning Rate Decay

### DIFF
--- a/examples/config/d4rl/halfcheetah_custom.py
+++ b/examples/config/d4rl/halfcheetah_custom.py
@@ -4,11 +4,11 @@ params = deepcopy(mopo_params)
 params.update({
     'domain': 'HalfCheetah',
     'task': 'v2',
-    'exp_name': 'halfcheetah_d3rlpy_pap5',
+    'exp_name': 'halfcheetah_d3rlpy_mp1',
     'seed': 4321,
 })
 params['kwargs'].update({
-    'pool_load_path': '/home/ajc348/rds/hpc-work/dogo_results/data/D3RLPY-PAP5-P1-4.npy',
+    'pool_load_path': '/home/ajc348/rds/hpc-work/dogo_results/data/D3RLPY-MP1-P1-4.npy',
     # 'model_load_dir': '/home/ajc348/rds/hpc-work/dogo_results/mopo/ray_mopo/HalfCheetah/halfcheetah_d3rlpy_pep4_101e3/seed:1443_2022-06-01_17-07-30wh6i6w19/models',
     'pool_load_max_size': 101000,
     'rollout_length': 5,

--- a/examples/config/d4rl/halfcheetah_custom.py
+++ b/examples/config/d4rl/halfcheetah_custom.py
@@ -4,14 +4,17 @@ params = deepcopy(mopo_params)
 params.update({
     'domain': 'HalfCheetah',
     'task': 'v2',
-    'exp_name': 'halfcheetah_d3rlpy_mp1',
+    'exp_name': 'halfcheetah_d3rlpy_pap5',
     'seed': 4321,
 })
 params['kwargs'].update({
-    'pool_load_path': '/home/ajc348/rds/hpc-work/dogo_results/data/D3RLPY-MP1-P1-4.npy',
+    'pool_load_path': '/home/ajc348/rds/hpc-work/dogo_results/data/D3RLPY-PAP5-P1-4.npy',
     # 'model_load_dir': '/home/ajc348/rds/hpc-work/dogo_results/mopo/ray_mopo/HalfCheetah/halfcheetah_d3rlpy_pep4_101e3/seed:1443_2022-06-01_17-07-30wh6i6w19/models',
     'pool_load_max_size': 101000,
     'rollout_length': 5,
     'penalty_coeff': 1.0,
     'holdout_policy': None,
+    # 'train_bnn_only': False,
+    'rex': False,
+    'rex_beta': 10.0,
 })


### PR DESCRIPTION
This PR introduces three key updates:

- enable only the training of dynamics models; allowing these to be evaluated before running SAC
- ability to use a pre-trained dynamics model in SAC training without running any additional epochs of training (previously one epoch of training would be run on the loaded model)
- if REx is not true, the $(1/\beta)$ learning rate decay term will still be applied to the sum of losses